### PR TITLE
feat: footer 모바일/데스크톱 분리 및 모바일 UI 추가

### DIFF
--- a/src/entities/content/ui/ContentCard.tsx
+++ b/src/entities/content/ui/ContentCard.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { type Content } from '../model/mock-data';
 import { CATEGORY_ES_MAP } from '../model/categories';
+import { Chip } from '@/shared/ui/chip/Chip';
 
 interface ContentCardProps {
   content: Content;
@@ -29,23 +30,36 @@ export default function ContentCard({ content, isKo }: ContentCardProps) {
           sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
           className="object-cover"
         />
-        <div className="absolute top-2 left-2 sm:top-3 sm:left-3 bg-black text-white text-[10px] sm:text-xs font-bold px-1.5 py-0.5 sm:px-2 sm:py-1 rounded">
-          {categoryLabel}
+        <div className="absolute top-2 left-2 sm:top-3 sm:left-3 z-10">
+          <Chip
+            text={categoryLabel}
+            color={
+              content.category.toLowerCase().includes('k-pop')
+                ? 'pink'
+                : content.category.toLowerCase().includes('drama')
+                  ? 'violet'
+                  : content.category.toLowerCase().includes('news')
+                    ? 'red'
+                    : content.category.toLowerCase().includes('society')
+                      ? 'blue'
+                      : 'gray'
+            }
+          />
         </div>
       </div>
 
       {/* Body */}
       <div className="p-3 sm:p-4 md:p-5 flex flex-col gap-1 sm:gap-2">
-        <div className="text-[10px] sm:text-xs text-gray-400 font-semibold">
+        {/* <div className="text-[10px] sm:text-xs text-gray-400 font-semibold">
           {content.publishedAt}
-        </div>
+        </div> */}
         <h2 className="text-xs sm:text-sm md:text-base font-bold leading-snug text-black line-clamp-2">
           {isKo ? content.title : content.titleEs}
         </h2>
-        <p className="hidden sm:block text-xs sm:text-sm text-gray-500 line-clamp-2 leading-relaxed">
+        {/* <p className="hidden sm:block text-xs sm:text-sm text-gray-500 line-clamp-2 leading-relaxed">
           {isKo ? content.summary : content.summaryEs}
-        </p>
-        <div className="flex items-center gap-1 mt-0.5 text-xs text-gray-400">
+        </p> */}
+        {/* <div className="flex items-center gap-1 mt-0.5 text-xs text-gray-400">
           <svg
             className="w-3 h-3 flex-shrink-0"
             fill="currentColor"
@@ -55,7 +69,7 @@ export default function ContentCard({ content, isKo }: ContentCardProps) {
             <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
           </svg>
           <span>{content.likes}</span>
-        </div>
+        </div> */}
       </div>
     </Link>
   );

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -1,12 +1,14 @@
 'use client';
 
 import { useRef, useCallback, Suspense, useState, useMemo } from 'react';
+import Image from 'next/image';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { useLanguageStore } from '@/shared/model';
 import { MOCK_CONTENTS, type Category, CATEGORIES_KO, CATEGORIES_ES } from '@/entities/content';
 import { ContentCard } from '@/entities/content';
 import { KoreaCarousel } from '@/widgets/korea-carousel';
+import { HotNewsCarousel } from '@/widgets/hot-news';
 
 const SORT_OPTIONS = [
   { id: 'latest' as const, ko: '최신순', es: 'Reciente' },
@@ -75,41 +77,9 @@ function HomePageInner() {
     <div>
       {/* ── Hero (main landing only) ── */}
       {isMainLanding && (
-        <section className="relative overflow-hidden mt-3 sm:mt-6 rounded-2xl md:rounded-3xl mx-0 sm:mx-2 md:mx-6 h-56 sm:h-80 lg:h-[540px]">
-          <KoreaCarousel isKo={isKo} fullHeight />
-
-          <div
-            className="absolute inset-0 z-20 flex flex-col items-center justify-center text-center px-4"
-            style={{
-              background: 'linear-gradient(to bottom, rgba(0,0,0,0.15) 0%, rgba(0,0,0,0.65) 100%)',
-            }}
-          >
-            <div className="mb-3 sm:mb-6">
-              <span className="px-3 py-1 sm:px-4 sm:py-1.5 rounded-full bg-red-600 text-white text-[9px] sm:text-[10px] font-black uppercase tracking-widest shadow-lg">
-                🔥 Hot Issue
-              </span>
-            </div>
-
-            <h1
-              className="text-2xl sm:text-4xl lg:text-6xl font-black text-white leading-tight mb-3 sm:mb-6 drop-shadow-2xl max-w-xs sm:max-w-2xl lg:max-w-4xl"
-              style={{ letterSpacing: '-0.03em' }}
-            >
-              {isKo ? '지금 가장 뜨거운 한국의 이야기' : 'Lo más candente de Corea ahora'}
-            </h1>
-
-            <p className="hidden sm:block text-sm md:text-lg text-white/90 mb-6 sm:mb-10 leading-relaxed max-w-2xl drop-shadow-md font-medium">
-              {isKo
-                ? '트렌드부터 깊이 있는 문화 분석까지, Corea Hoy가 선별한 프리미엄 콘텐츠를 만나보세요.'
-                : 'Desde tendencias hasta análisis culturales profundos, descubre el contenido premium seleccionado por Corea Hoy.'}
-            </p>
-
-            <button
-              onClick={scrollToContent}
-              className="group flex items-center gap-2 px-6 sm:px-10 py-2.5 sm:py-4 rounded-full bg-white text-black text-sm sm:text-base font-black hover:bg-gray-100 transition-all shadow-2xl hover:-translate-y-1 active:scale-95 cursor-pointer"
-            >
-              {t('heroCta')}
-              <span className="transition-transform group-hover:translate-y-1">↓</span>
-            </button>
+        <section className="bg-white py-6 sm:py-10 px-4 sm:px-6">
+          <div className="max-w-screen-xl mx-auto relative z-10">
+            <HotNewsCarousel isKo={isKo} />
           </div>
         </section>
       )}
@@ -118,7 +88,7 @@ function HomePageInner() {
       <div
         ref={contentRef}
         id="newsletter"
-        className="max-w-screen-xl mx-auto pt-5 sm:pt-8 scroll-mt-20"
+        className="max-w-screen-xl mx-auto pt-10 px-6 scroll-mt-20"
       >
         {/* Header row: title + sort tabs */}
         <div className="mb-5 sm:mb-6">
@@ -133,9 +103,9 @@ function HomePageInner() {
                 : t('newsletterTitle')}
             </h2>
 
-            {/* Sort tabs — only on home/search, not single-category view */}
+            {/* 정렬 버튼 */}
             {!activeCategory && (
-              <div className="flex items-center gap-1 bg-gray-100 p-1 rounded-xl border border-gray-200 flex-shrink-0 mt-1">
+              <div className="flex items-center gap-1 bg-white p-1 rounded-xl border border-gray-200 flex-shrink-0 mt-1">
                 {SORT_OPTIONS.map((opt) => (
                   <button
                     key={opt.id}

--- a/src/widgets/footer/footer/DeskTopFooter.tsx
+++ b/src/widgets/footer/footer/DeskTopFooter.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import Link from 'next/link';
+import Image from 'next/image';
+import { useTranslations } from 'next-intl';
+
+export default function DeskTopFooter() {
+  const t = useTranslations('footer');
+  const year = new Date().getFullYear();
+
+  const navLinks = [
+    { href: '/feedback', label: t('feedback') },
+    { href: '/privacy', label: t('privacy') },
+  ];
+
+  return (
+    <>
+      <footer className="hidden lg:block mt-20 border-t border-gray-100 bg-gray-50">
+        <div className="max-w-screen-xl mx-auto px-6 py-12">
+          <div className="grid grid-cols-1 md:grid-cols-[1fr_auto] gap-10">
+            {/* Brand & Description */}
+            <div className="max-w-sm">
+              <Link href="/" className="inline-block mb-4 hover:opacity-70 transition-opacity">
+                <Image
+                  src="/images/logo/logo.svg"
+                  alt="Corea Hoy"
+                  width={110}
+                  height={44}
+                  style={{ objectFit: 'contain' }}
+                />
+              </Link>
+              <p className="text-sm font-semibold text-gray-700 mb-2">{t('tagline')}</p>
+              <p className="text-xs text-gray-400 leading-relaxed">{t('desc')}</p>
+              <div className="mt-4 inline-flex items-center gap-1.5 px-3 py-1 bg-amber-50 border border-amber-200 rounded-full">
+                <span className="w-1.5 h-1.5 rounded-full bg-amber-400 animate-pulse" />
+                <span className="text-xs text-amber-600 font-semibold">{t('demo')}</span>
+              </div>
+            </div>
+
+            {/* Nav links */}
+            <div>
+              <p className="text-xs font-bold text-gray-400 uppercase tracking-widest mb-3">
+                {t('nav')}
+              </p>
+              <ul className="flex flex-col gap-2">
+                {navLinks.map(({ href, label }) => (
+                  <li key={href}>
+                    <Link
+                      href={href}
+                      className="text-sm text-gray-500 hover:text-black transition-colors"
+                    >
+                      {label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+              <div className="mt-5">
+                <p className="text-xs font-bold text-gray-400 uppercase tracking-widest mb-2">
+                  {t('contact')}
+                </p>
+                <a
+                  href={`mailto:${t('email')}`}
+                  className="text-sm text-gray-500 hover:text-black transition-colors"
+                >
+                  {t('email')}
+                </a>
+              </div>
+            </div>
+          </div>
+
+          {/* Bottom bar */}
+          <div className="mt-10 pt-6 border-t border-gray-200 flex flex-col sm:flex-row items-center justify-between gap-2 text-xs text-gray-400">
+            <span>
+              © {year} Corea Hoy. {t('rights')}
+            </span>
+            <span className="hidden sm:inline">·</span>
+            <span>Made with ❤️ for Latin America</span>
+          </div>
+        </div>
+      </footer>
+    </>
+  );
+}

--- a/src/widgets/footer/footer/Footer.tsx
+++ b/src/widgets/footer/footer/Footer.tsx
@@ -1,81 +1,13 @@
 'use client';
 
-import Link from 'next/link';
-import Image from 'next/image';
-import { useTranslations } from 'next-intl';
+import DeskTopFooter from './DeskTopFooter';
+import MobileFooter from './MobileFooter';
 
 export default function Footer() {
-  const t = useTranslations('footer');
-  const year = new Date().getFullYear();
-
-  const navLinks = [
-    { href: '/feedback', label: t('feedback') },
-    { href: '/privacy', label: t('privacy') },
-  ];
-
   return (
-    <footer className="mt-20 border-t border-gray-100 bg-gray-50">
-      <div className="max-w-screen-xl mx-auto px-6 py-12">
-        <div className="grid grid-cols-1 md:grid-cols-[1fr_auto] gap-10">
-          {/* Brand & Description */}
-          <div className="max-w-sm">
-            <Link href="/" className="inline-block mb-4 hover:opacity-70 transition-opacity">
-              <Image
-                src="/images/logo/logo.svg"
-                alt="Corea Hoy"
-                width={110}
-                height={44}
-                style={{ objectFit: 'contain' }}
-              />
-            </Link>
-            <p className="text-sm font-semibold text-gray-700 mb-2">{t('tagline')}</p>
-            <p className="text-xs text-gray-400 leading-relaxed">{t('desc')}</p>
-            <div className="mt-4 inline-flex items-center gap-1.5 px-3 py-1 bg-amber-50 border border-amber-200 rounded-full">
-              <span className="w-1.5 h-1.5 rounded-full bg-amber-400 animate-pulse" />
-              <span className="text-xs text-amber-600 font-semibold">{t('demo')}</span>
-            </div>
-          </div>
-
-          {/* Nav links */}
-          <div>
-            <p className="text-xs font-bold text-gray-400 uppercase tracking-widest mb-3">
-              {t('nav')}
-            </p>
-            <ul className="flex flex-col gap-2">
-              {navLinks.map(({ href, label }) => (
-                <li key={href}>
-                  <Link
-                    href={href}
-                    className="text-sm text-gray-500 hover:text-black transition-colors"
-                  >
-                    {label}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-            <div className="mt-5">
-              <p className="text-xs font-bold text-gray-400 uppercase tracking-widest mb-2">
-                {t('contact')}
-              </p>
-              <a
-                href={`mailto:${t('email')}`}
-                className="text-sm text-gray-500 hover:text-black transition-colors"
-              >
-                {t('email')}
-              </a>
-            </div>
-          </div>
-        </div>
-
-        {/* Bottom bar */}
-        <div className="mt-10 pt-6 border-t border-gray-200 flex flex-col sm:flex-row items-center justify-between gap-2 text-xs text-gray-400">
-          <span>
-            © {year} Corea Hoy. {t('rights')}
-          </span>
-          <span className="hidden sm:inline">·</span>
-          <span>Made with ❤️ for Latin America</span>
-        </div>
-      </div>
-    </footer>
+    <div>
+      <DeskTopFooter />
+      <MobileFooter />
+    </div>
   );
 }

--- a/src/widgets/footer/footer/MobileFooter.tsx
+++ b/src/widgets/footer/footer/MobileFooter.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+
+export default function MobileFooter() {
+  const t = useTranslations('footer');
+  const year = new Date().getFullYear();
+
+  return (
+    <footer className="lg:hidden mt-6 border-t border-gray-100 bg-white pb-16">
+      <div className="px-4 py-3 flex items-center justify-between gap-4">
+        {/* 왼쪽 영역: 링크 + 구분선 + 저작권 (말줄임 적용) */}
+        <div className="flex items-center gap-3 min-w-0 flex-1">
+          <Link
+            href="/privacy"
+            className="text-xs text-gray-500 hover:text-black transition-colors whitespace-nowrap flex-shrink-0"
+          >
+            {t('privacy')}
+          </Link>
+
+          {/* 구분선 */}
+          <span className="text-gray-200 text-[10px] flex-shrink-0">|</span>
+
+          {/* 화면이 좁아지면 ...으로 변하는 저작권 부분 */}
+          <span className="text-xs text-gray-400 truncate">© {year} Corea Hoy</span>
+        </div>
+
+        {/* 오른쪽 영역: 베타 서비스 뱃지 */}
+        <div className="inline-flex items-center gap-1 px-2.5 py-0.5 bg-amber-50 border border-amber-200 rounded-full flex-shrink-0">
+          <span className="w-1.5 h-1.5 rounded-full bg-amber-400 animate-pulse" />
+          <span className="text-[10px] text-amber-600 font-semibold whitespace-nowrap">
+            {t('demo')}
+          </span>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/widgets/hot-news/index.ts
+++ b/src/widgets/hot-news/index.ts
@@ -1,0 +1,1 @@
+export { default as HotNewsCarousel } from './ui/HotNewsCarousel';

--- a/src/widgets/hot-news/ui/HotNewsCarousel.tsx
+++ b/src/widgets/hot-news/ui/HotNewsCarousel.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
+import { MOCK_CONTENTS } from '@/entities/content';
+import { Chip } from '@/shared/ui/chip/Chip';
+
+interface HotNewsCarouselProps {
+  isKo: boolean;
+}
+
+const GAP = 20;
+const INTERVAL = 5000;
+const MIN_SWIPE = 40;
+
+function getVisibleCount() {
+  if (typeof window === 'undefined') return 3;
+  if (window.innerWidth >= 1280) return 3;
+  if (window.innerWidth >= 1024) return 2.5;
+  if (window.innerWidth >= 640) return 1.5;
+  return 1.1;
+}
+
+export default function HotNewsCarousel({ isKo }: HotNewsCarouselProps) {
+  const hotItems = MOCK_CONTENTS.filter((c) => c.status === 'published')
+    .sort((a, b) => b.likes - a.likes)
+    .slice(0, 8);
+
+  const [current, setCurrent] = useState(0);
+  const [paused, setPaused] = useState(false);
+  const [visibleCount, setVisibleCount] = useState(3);
+  const [translateX, setTranslateX] = useState(0);
+  const trackRef = useRef<HTMLDivElement>(null);
+  const touchStartX = useRef<number | null>(null);
+
+  const maxIndex = Math.max(0, hotItems.length - Math.floor(visibleCount));
+
+  const calcTranslate = useCallback((index: number, vc: number) => {
+    if (!trackRef.current) return 0;
+    const w = trackRef.current.offsetWidth;
+    const cardW = (w - GAP * (Math.ceil(vc) - 1)) / vc;
+    return index * (cardW + GAP);
+  }, []);
+
+  const goTo = useCallback(
+    (index: number) => {
+      const clamped = Math.max(0, Math.min(index, maxIndex));
+      setCurrent(clamped);
+      setTranslateX(calcTranslate(clamped, visibleCount));
+    },
+    [maxIndex, visibleCount, calcTranslate],
+  );
+
+  const next = useCallback(
+    () => goTo(current >= maxIndex ? 0 : current + 1),
+    [current, maxIndex, goTo],
+  );
+  const prev = useCallback(
+    () => goTo(current <= 0 ? maxIndex : current - 1),
+    [current, maxIndex, goTo],
+  );
+
+  useEffect(() => {
+    const update = () => {
+      const vc = getVisibleCount();
+      setVisibleCount(vc);
+      setCurrent((c) => {
+        const max = Math.max(0, hotItems.length - Math.floor(vc));
+        const clamped = Math.min(c, max);
+        setTranslateX(calcTranslate(clamped, vc));
+        return clamped;
+      });
+    };
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }, [calcTranslate, hotItems.length]);
+
+  useEffect(() => {
+    if (paused) return;
+    const id = setInterval(next, INTERVAL);
+    return () => clearInterval(id);
+  }, [paused, next]);
+
+  const onTouchStart = (e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0].clientX;
+  };
+  const onTouchEnd = (e: React.TouchEvent) => {
+    if (touchStartX.current === null) return;
+    const delta = touchStartX.current - e.changedTouches[0].clientX;
+    if (Math.abs(delta) >= MIN_SWIPE) delta > 0 ? next() : prev();
+    touchStartX.current = null;
+  };
+
+  const cardStyle = {
+    flexShrink: 0 as const,
+    width: `calc((100% - ${GAP * (Math.ceil(visibleCount) - 1)}px) / ${visibleCount})`,
+  };
+
+  return (
+    <div className="relative w-full">
+      {/* Navigation Arrows - Top Right */}
+      <div className="flex items-center justify-end gap-2 mb-3 sm:mb-4">
+        <button
+          onClick={prev}
+          className="w-10 h-10 rounded-full border border-gray-200 flex items-center justify-center transition-all cursor-pointer hover:bg-gray-50 active:scale-90"
+        >
+          <span className="text-gray-600 text-xl">‹</span>
+        </button>
+        <button
+          onClick={next}
+          className="w-10 h-10 rounded-full border border-gray-200 flex items-center justify-center transition-all cursor-pointer hover:bg-gray-50 active:scale-90"
+        >
+          <span className="text-gray-600 text-xl">›</span>
+        </button>
+        <div className="ml-4 text-[11px] font-black text-gray-400 tracking-widest">
+          {String(current + 1).padStart(2, '0')} /{' '}
+          {String(hotItems.length - Math.floor(visibleCount) + 1).padStart(2, '0')}
+        </div>
+      </div>
+
+      <section
+        onMouseEnter={() => setPaused(true)}
+        onMouseLeave={() => setPaused(false)}
+        className="relative"
+      >
+        <div
+          ref={trackRef}
+          className="overflow-hidden"
+          onTouchStart={onTouchStart}
+          onTouchEnd={onTouchEnd}
+        >
+          <div
+            className="flex transition-transform duration-700 cubic-bezier(0.23, 1, 0.32, 1)"
+            style={{ gap: `${GAP}px`, transform: `translateX(-${translateX}px)` }}
+          >
+            {hotItems.map((item) => (
+              <Link key={item.id} href={`/detail/${item.id}`} style={cardStyle}>
+                <div className="group h-[360px] sm:h-[400px] lg:h-[460px] bg-black rounded-2xl overflow-hidden transition-all duration-500  hover:-translate-y-2 relative flex flex-col">
+                  {/* Card Background Image */}
+                  <Image
+                    src={`https://picsum.photos/seed/${item.id}/1200/1600`}
+                    alt={isKo ? item.title : item.titleEs}
+                    fill
+                    className="object-cover opacity-70 group-hover:opacity-90 transition-all duration-700 group-hover:scale-110"
+                  />
+
+                  {/* Category Chip - Top Left */}
+                  <div className="absolute top-4 left-4 z-30">
+                    <Chip
+                      text={item.category}
+                      color={
+                        item.category.toLowerCase().includes('k-pop')
+                          ? 'pink'
+                          : item.category.toLowerCase().includes('drama')
+                            ? 'violet'
+                            : item.category.toLowerCase().includes('news')
+                              ? 'red'
+                              : item.category.toLowerCase().includes('society')
+                                ? 'blue'
+                                : 'blue'
+                      }
+                    />
+                  </div>
+
+                  {/* Dark Gradient Overlay */}
+                  <div className="absolute inset-0 bg-gradient-to-t from-black via-black/20 to-transparent z-10" />
+
+                  {/* Content Overlay - Bottom */}
+                  <div className="relative z-20 p-5 sm:p-6 flex flex-col h-full justify-end items-start">
+                    <h3 className="text-base sm:text-lg lg:text-xl font-black text-white leading-tight mb-2 drop-shadow-md group-hover:text-blue-400 transition-colors">
+                      {isKo ? item.title : item.titleEs}
+                    </h3>
+                    <p className="text-[11px] sm:text-xs text-white/70 leading-relaxed line-clamp-2 opacity-0 group-hover:opacity-100 transition-all duration-300 transform translate-y-2 group-hover:translate-y-0">
+                      {isKo ? item.summary : item.summaryEs}
+                    </p>
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#14 

### 📝 작업 내용
모바일 footer UI 추가 및 추천 뉴스 섹션을 추가하였습니다

### 스크린샷 (선택)

- 추천뉴스
<img width="1350" height="695" alt="image" src="https://github.com/user-attachments/assets/64b0382d-a031-43cf-8186-9c1f87e31941" />

---
- 모바일 Footer
<img width="1410" height="182" alt="image" src="https://github.com/user-attachments/assets/d02a66d6-f6b2-4f13-8728-a826031a90bb" />


## 💬 리뷰 요구사항(선택)

UI가 어색하지 않은지 봐주세요! 


## 📚 참고할만한 자료(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced interactive hot news carousel on the home page featuring auto-advancing slides and touch/swipe navigation capabilities

* **UI & Style Updates**
  * Redesigned footer with responsive layouts specifically optimized for mobile and desktop viewing experiences
  * Enhanced content card styling with dynamically colored category labels based on content type
  * Updated home page hero section layout and sort tabs styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->