### PR TITLE
Feature/mypage layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,7 +19,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="ko">
       <IntlProvider>
-        <body className="bg-white text-black min-h-screen">
+        <body className="bg-white text-black min-h-screen flex flex-col">
           <Header />
           <main className="flex-1 max-w-screen-xl mx-auto w-full px-4 pb-20 lg:pb-0">
             <Providers>{children}</Providers>

--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -1,0 +1,5 @@
+import { MyPage } from '@/views/mypage';
+
+export default function Page() {
+  return <MyPage />;
+}

--- a/src/entities/user/model/userStore.ts
+++ b/src/entities/user/model/userStore.ts
@@ -43,9 +43,21 @@ export const useUserStore = create<UserState>()(
         }),
 
       updateProfile: (name, avatarEmoji, avatarColor) =>
-        set((state) => ({
-          user: state.user ? { ...state.user, name, avatarEmoji, avatarColor } : null,
-        })),
+        set((state) => {
+          if (state.user) {
+            return { user: { ...state.user, name, avatarEmoji, avatarColor } };
+          }
+          return {
+            user: {
+              name,
+              email: 'test@example.com',
+              avatarEmoji,
+              avatarColor,
+              likedContentIds: ['c1', 'c3'],
+            },
+            isLoggedIn: true,
+          };
+        }),
 
       toggleLike: (contentId) =>
         set((state) => {

--- a/src/shared/ui/avatar/Avatar.tsx
+++ b/src/shared/ui/avatar/Avatar.tsx
@@ -1,0 +1,17 @@
+interface AvatarProps {
+  emoji: string;
+  color: string;
+  size?: number;
+  className?: string;
+}
+
+export function Avatar({ emoji, color, size = 72, className = '' }: AvatarProps) {
+  return (
+    <div
+      className={`rounded-full flex items-center justify-center flex-shrink-0 shadow-sm ${className}`}
+      style={{ width: size, height: size, backgroundColor: color, fontSize: size * 0.44 }}
+    >
+      {emoji}
+    </div>
+  );
+}

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -2,3 +2,4 @@ export { Chip } from './chip/Chip';
 export { Stepper } from './stepper/Stepper';
 export { ConfirmModal } from './modal/ConfirmModal';
 export { Loading } from './loading/Loading';
+export { Avatar } from './avatar/Avatar';

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -77,7 +77,7 @@ function HomePageInner() {
     <div>
       {/* ── Hero (main landing only) ── */}
       {isMainLanding && (
-        <section className="bg-white py-6 sm:py-10 px-4 sm:px-6">
+        <section className="bg-white py-6 sm:py-10 ">
           <div className="max-w-screen-xl mx-auto relative z-10">
             <HotNewsCarousel isKo={isKo} />
           </div>
@@ -85,11 +85,7 @@ function HomePageInner() {
       )}
 
       {/* ── Content area ── */}
-      <div
-        ref={contentRef}
-        id="newsletter"
-        className="max-w-screen-xl mx-auto pt-10 px-6 scroll-mt-20"
-      >
+      <div ref={contentRef} id="newsletter" className="max-w-screen-xl mx-auto pt-10  scroll-mt-20">
         {/* Header row: title + sort tabs */}
         <div className="mb-5 sm:mb-6">
           <div className="flex items-start justify-between gap-3 mb-3">

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -1,13 +1,11 @@
 'use client';
 
-import { useRef, useCallback, Suspense, useState, useMemo } from 'react';
-import Image from 'next/image';
+import { useRef, Suspense, useState, useMemo } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { useLanguageStore } from '@/shared/model';
 import { MOCK_CONTENTS, type Category, CATEGORIES_KO, CATEGORIES_ES } from '@/entities/content';
 import { ContentCard } from '@/entities/content';
-import { KoreaCarousel } from '@/widgets/korea-carousel';
 import { HotNewsCarousel } from '@/widgets/hot-news';
 
 const SORT_OPTIONS = [
@@ -63,10 +61,6 @@ function HomePageInner() {
 
   const categories: Category[] = ['K-POP', '드라마', '뉴스', '문화', '스포츠', '음식'];
 
-  const scrollToContent = useCallback(() => {
-    contentRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-  }, []);
-
   const handleCategoryViewMore = (cat: string) => {
     const params = new URLSearchParams();
     params.set('category', cat);
@@ -100,7 +94,7 @@ function HomePageInner() {
             </h2>
 
             {/* 정렬 버튼 */}
-            {!activeCategory && (
+            {activeCategory && (
               <div className="flex items-center gap-1 bg-white p-1 rounded-xl border border-gray-200 flex-shrink-0 mt-1">
                 {SORT_OPTIONS.map((opt) => (
                   <button

--- a/src/views/mypage/index.ts
+++ b/src/views/mypage/index.ts
@@ -1,0 +1,1 @@
+export { MyPage } from './ui/MyPage';

--- a/src/views/mypage/ui/LikedContentList.tsx
+++ b/src/views/mypage/ui/LikedContentList.tsx
@@ -1,0 +1,61 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import { useTranslations } from 'next-intl';
+
+// Define the type inline or import if available
+interface LikedContent {
+  id: string;
+  category: string;
+  title: string;
+  titleEs: string;
+  publishedAt: string;
+}
+
+interface LikedContentListProps {
+  contents: LikedContent[];
+  isKo: boolean;
+}
+
+export function LikedContentList({ contents, isKo }: LikedContentListProps) {
+  const t = useTranslations('mypage');
+
+  return (
+    <section className="mb-8">
+      <h2 className="text-xl font-bold mb-4">♥ {t('likedTitle')}</h2>
+      {contents.length === 0 ? (
+        <p className="text-center text-gray-300 py-12 border border-dashed border-gray-200 rounded-2xl text-sm">
+          {t('emptyLike')}
+        </p>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          {contents.map((c) => (
+            <Link
+              key={c.id}
+              href={`/detail/${c.id}`}
+              className="group flex gap-3 border border-gray-100 bg-white rounded-xl overflow-hidden hover:border-black transition-all duration-200"
+            >
+              <div className="relative w-24 h-20 flex-shrink-0">
+                <Image
+                  src={`https://picsum.photos/seed/${c.id}/240/160`}
+                  alt={isKo ? c.title : c.titleEs}
+                  fill
+                  sizes="96px"
+                  className="object-cover"
+                />
+              </div>
+              <div className="flex flex-col justify-center gap-1 py-3 pr-3 min-w-0">
+                <span className="text-[10px] bg-gray-100 px-2 py-0.5 rounded font-semibold text-gray-500 self-start">
+                  {c.category}
+                </span>
+                <p className="font-bold text-sm leading-snug group-hover:underline line-clamp-2">
+                  {isKo ? c.title : c.titleEs}
+                </p>
+                <span className="text-xs text-gray-300">{c.publishedAt}</span>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/views/mypage/ui/MyCommentsList.tsx
+++ b/src/views/mypage/ui/MyCommentsList.tsx
@@ -1,0 +1,44 @@
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+
+interface MyComment {
+  id: string;
+  contentId: string;
+  contentTitle: string;
+  body: string;
+  createdAt: string;
+}
+
+interface MyCommentsListProps {
+  comments: MyComment[];
+}
+
+export function MyCommentsList({ comments }: MyCommentsListProps) {
+  const t = useTranslations('mypage');
+
+  return (
+    <section>
+      <h2 className="text-xl font-bold mb-4">💬 {t('commentTitle')}</h2>
+      {comments.length === 0 ? (
+        <p className="text-center text-gray-300 py-12 border border-dashed border-gray-200 rounded-2xl text-sm">
+          {t('emptyComment')}
+        </p>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {comments.map((cm) => (
+            <div key={cm.id} className="border border-gray-100 bg-white rounded-xl p-4">
+              <Link
+                href={`/detail/${cm.contentId}`}
+                className="text-sm text-blue-500 font-semibold hover:underline"
+              >
+                {cm.contentTitle}
+              </Link>
+              <p className="mt-2 text-sm text-gray-600 leading-relaxed">{cm.body}</p>
+              <span className="text-xs text-gray-300 mt-1 block">{cm.createdAt}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/views/mypage/ui/MyPage.tsx
+++ b/src/views/mypage/ui/MyPage.tsx
@@ -25,8 +25,10 @@ export function MyPage() {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setMounted(true);
+    const timer = setTimeout(() => {
+      setMounted(true);
+    }, 0);
+    return () => clearTimeout(timer);
   }, []);
 
   const currentUser = user || {
@@ -39,6 +41,10 @@ export function MyPage() {
   };
 
   if (!mounted) return null;
+
+  // TODO: 로그인 기능 추가 후 주석 해제
+  //   if (!mounted || !user) return null;
+  // const currentUser = user;
 
   const likedContents = MOCK_CONTENTS.filter((c) => currentUser.likedContentIds.includes(c.id));
   const myComments = MOCK_CONTENTS.flatMap((c) =>
@@ -100,10 +106,10 @@ export function MyPage() {
           onDeleteAccount={() => setShowDeleteModal(true)}
         />
 
-        <main>
+        <section>
           <LikedContentList contents={likedContents} isKo={isKo} />
           <MyCommentsList comments={myComments} />
-        </main>
+        </section>
       </div>
 
       {showDeleteModal && (

--- a/src/views/mypage/ui/MyPage.tsx
+++ b/src/views/mypage/ui/MyPage.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTranslations, useLocale } from 'next-intl';
+import { useUserStore, AVATAR_PRESETS } from '@/entities/user';
+import { MOCK_CONTENTS, MOCK_USER } from '@/entities/content/model/mock-data';
+
+import { ProfileCard } from './ProfileCard';
+import { LikedContentList } from './LikedContentList';
+import { MyCommentsList } from './MyCommentsList';
+
+export function MyPage() {
+  const router = useRouter();
+  const t = useTranslations('mypage');
+  const locale = useLocale();
+  const { user, updateProfile, logout, deleteAccount } = useUserStore();
+  const isKo = locale === 'ko';
+
+  const [mounted, setMounted] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [tempNickname, setTempNickname] = useState('');
+  const [tempAvatar, setTempAvatar] = useState(AVATAR_PRESETS[0]);
+  const [nicknameError, setNicknameError] = useState('');
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setMounted(true);
+  }, []);
+
+  const currentUser = user || {
+    id: 'mock-id',
+    name: '테스트 유저',
+    email: 'test@example.com',
+    avatarEmoji: '',
+    avatarColor: '#ffd0a8',
+    likedContentIds: ['c1', 'c3'],
+  };
+
+  if (!mounted) return null;
+
+  const likedContents = MOCK_CONTENTS.filter((c) => currentUser.likedContentIds.includes(c.id));
+  const myComments = MOCK_CONTENTS.flatMap((c) =>
+    c.comments
+      .filter((cm) => cm.userId === MOCK_USER.id)
+      .map((cm) => ({ ...cm, contentTitle: isKo ? c.title : c.titleEs, contentId: c.id })),
+  );
+
+  function startEdit() {
+    setTempNickname(currentUser.name);
+    setTempAvatar(
+      AVATAR_PRESETS.find((p) => p.emoji === currentUser.avatarEmoji) ?? AVATAR_PRESETS[0],
+    );
+    setNicknameError('');
+    setEditing(true);
+  }
+
+  function handleSave() {
+    const trimmed = tempNickname.trim();
+    if (trimmed.length < 2 || trimmed.length > 20) {
+      setNicknameError(t('nicknameError'));
+      return;
+    }
+    updateProfile(trimmed, tempAvatar.emoji, tempAvatar.color);
+    setEditing(false);
+  }
+
+  function handleLogout() {
+    logout();
+    router.push('/');
+  }
+
+  function handleDeleteAccount() {
+    deleteAccount();
+    router.push('/');
+  }
+
+  return (
+    <div className="py-6 md:py-10">
+      <h1 className="text-3xl md:text-4xl font-extrabold mb-8">{t('title')}</h1>
+
+      <div className="lg:grid lg:grid-cols-[320px_1fr] lg:gap-10 lg:items-start">
+        <ProfileCard
+          user={currentUser}
+          editing={editing}
+          tempNickname={tempNickname}
+          tempAvatar={tempAvatar}
+          nicknameError={nicknameError}
+          stats={{ likes: likedContents.length, comments: myComments.length }}
+          onStartEdit={startEdit}
+          onSave={handleSave}
+          onCancelEdit={() => setEditing(false)}
+          onAvatarChange={setTempAvatar}
+          onNicknameChange={(val) => {
+            setTempNickname(val);
+            setNicknameError('');
+          }}
+          onLogout={handleLogout}
+          onDeleteAccount={() => setShowDeleteModal(true)}
+        />
+
+        <main>
+          <LikedContentList contents={likedContents} isKo={isKo} />
+          <MyCommentsList comments={myComments} />
+        </main>
+      </div>
+
+      {showDeleteModal && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-3xl p-8 max-w-sm w-full text-center shadow-xl">
+            <div className="text-4xl mb-4">⚠️</div>
+            <h3 className="font-black text-lg mb-2">{t('deleteConfirmTitle')}</h3>
+            <p className="text-sm text-gray-500 leading-relaxed mb-6">{t('deleteConfirmDesc')}</p>
+            <div className="flex gap-3">
+              <button
+                onClick={() => setShowDeleteModal(false)}
+                className="flex-1 py-3 border border-gray-200 bg-white rounded-xl font-semibold text-sm cursor-pointer hover:bg-gray-50 transition-colors"
+              >
+                {t('deleteCancel')}
+              </button>
+              <button
+                onClick={handleDeleteAccount}
+                className="flex-1 py-3 bg-red-500 text-white rounded-xl font-bold text-sm cursor-pointer hover:bg-red-600 transition-colors"
+              >
+                {t('deleteConfirm')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/views/mypage/ui/ProfileCard.tsx
+++ b/src/views/mypage/ui/ProfileCard.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { Avatar } from '@/shared/ui';
+import { UserProfile, AVATAR_PRESETS } from '@/entities/user';
+
+interface ProfileCardProps {
+  user: UserProfile;
+  editing: boolean;
+  tempNickname: string;
+  tempAvatar: { emoji: string; color: string };
+  nicknameError: string;
+  stats: { likes: number; comments: number };
+  onStartEdit: () => void;
+  onSave: () => void;
+  onCancelEdit: () => void;
+  onAvatarChange: (preset: { emoji: string; color: string }) => void;
+  onNicknameChange: (val: string) => void;
+  onLogout: () => void;
+  onDeleteAccount: () => void;
+}
+
+export function ProfileCard({
+  user,
+  editing,
+  tempNickname,
+  tempAvatar,
+  nicknameError,
+  stats,
+  onStartEdit,
+  onSave,
+  onCancelEdit,
+  onAvatarChange,
+  onNicknameChange,
+  onLogout,
+  onDeleteAccount,
+}: ProfileCardProps) {
+  const t = useTranslations('mypage');
+
+  return (
+    <aside className="mb-8 lg:mb-0">
+      <div className="lg:sticky lg:top-24">
+        <section className="bg-white border border-gray-100 rounded-2xl p-6 shadow-sm">
+          {/* Avatar + name */}
+          <div className="flex items-center gap-4 mb-5">
+            <Avatar
+              emoji={editing ? tempAvatar.emoji : user.avatarEmoji}
+              color={editing ? tempAvatar.color : user.avatarColor}
+            />
+            <div className="flex-1 min-w-0">
+              <div className="text-lg font-bold truncate">{user.name}</div>
+              <div className="text-sm text-gray-400 mt-0.5 truncate">{user.email}</div>
+            </div>
+          </div>
+
+          {/* Stats */}
+          {!editing && (
+            <div className="flex gap-6 mb-5 pb-5 border-b border-gray-100">
+              <div className="text-center">
+                <div className="text-2xl font-black">{stats.likes}</div>
+                <div className="text-xs text-gray-400 mt-0.5">{t('likes')}</div>
+              </div>
+              <div className="text-center">
+                <div className="text-2xl font-black">{stats.comments}</div>
+                <div className="text-xs text-gray-400 mt-0.5">{t('comments')}</div>
+              </div>
+            </div>
+          )}
+
+          {!editing ? (
+            <button
+              onClick={onStartEdit}
+              className="w-full py-2.5 border border-gray-200 rounded-xl text-sm font-semibold text-gray-600 hover:bg-gray-50 transition-colors cursor-pointer"
+            >
+              {t('editProfile')}
+            </button>
+          ) : (
+            /* Edit form */
+            <div>
+              <div className="mb-4">
+                <div className="text-sm font-bold mb-2">{t('avatarLabel')}</div>
+                <div className="grid grid-cols-6 gap-1.5">
+                  {AVATAR_PRESETS.map((preset) => {
+                    const isSelected = tempAvatar.emoji === preset.emoji;
+                    return (
+                      <button
+                        key={preset.emoji}
+                        type="button"
+                        onClick={() => onAvatarChange(preset)}
+                        className={`aspect-square rounded-full flex items-center justify-center text-xl transition-all cursor-pointer border-2 ${
+                          isSelected
+                            ? 'border-black scale-110'
+                            : 'border-transparent hover:scale-105'
+                        }`}
+                        style={{ backgroundColor: preset.color }}
+                      >
+                        {preset.emoji}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div className="mb-4">
+                <div className="text-sm font-bold mb-2">{t('nicknameLabel')}</div>
+                <input
+                  type="text"
+                  value={tempNickname}
+                  onChange={(e) => onNicknameChange(e.target.value)}
+                  placeholder={t('nicknamePlaceholder')}
+                  maxLength={20}
+                  className={`w-full px-4 py-2.5 rounded-xl border text-sm bg-gray-50 outline-none transition-colors ${
+                    nicknameError ? 'border-red-400' : 'border-gray-200 focus:border-black'
+                  }`}
+                />
+                {nicknameError && <p className="text-red-500 text-xs mt-1">{nicknameError}</p>}
+              </div>
+
+              <div className="flex gap-2">
+                <button
+                  onClick={onSave}
+                  className="flex-1 py-2.5 bg-black text-white rounded-xl text-sm font-bold cursor-pointer hover:opacity-80 transition-opacity"
+                >
+                  {t('save')}
+                </button>
+                <button
+                  onClick={onCancelEdit}
+                  className="flex-1 py-2.5 border border-gray-200 bg-white text-gray-500 rounded-xl text-sm font-semibold cursor-pointer hover:bg-gray-50 transition-colors"
+                >
+                  {t('cancel')}
+                </button>
+              </div>
+            </div>
+          )}
+        </section>
+
+        {/* Account actions */}
+        <div className="mt-4 flex justify-between items-center px-2">
+          <button
+            onClick={onDeleteAccount}
+            className="text-sm text-red-500 font-semibold hover:text-red-600 transition-colors cursor-pointer bg-transparent border-none p-0"
+          >
+            {t('deleteAccount')}
+          </button>
+          <button
+            onClick={onLogout}
+            className="px-4 py-2 border border-gray-200 text-gray-500 rounded-xl text-sm font-semibold hover:bg-gray-50 transition-colors cursor-pointer"
+          >
+            {t('logout')}
+          </button>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/src/widgets/hot-news/ui/HotNewsCarousel.tsx
+++ b/src/widgets/hot-news/ui/HotNewsCarousel.tsx
@@ -127,7 +127,7 @@ export default function HotNewsCarousel({ isKo }: HotNewsCarouselProps) {
       >
         <div
           ref={trackRef}
-          className="overflow-hidden"
+          className="overflow-hidden py-4 -my-4"
           onTouchStart={onTouchStart}
           onTouchEnd={onTouchEnd}
         >


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#20 

### 📝 작업 내용

마이페이지 추가 및 각 뉴스 및 슬라이더 바의 padding 제거

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)


## 📚 참고할만한 자료(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 마이 페이지 추가: 프로필 카드, 좋아요 목록, 내 댓글 섹션 제공
  * 프로필 편집: 닉네임 검증, 아바타 이모지/색상 선택, 저장/취소 지원
  * 아바타 컴포넌트 추가 및 재사용 가능 UI 제공

* **동작 개선**
  * 프로필 업데이트 흐름 개선(편집·저장·로그아웃·계정삭제 연동)
  * 정렬 컨트롤 노출 조건 개선

* **스타일**
  * 루트 레이아웃을 세로 플렉스 구조로 변경
  * 홈 레이아웃 패딩 조정 및 핫뉴스 캐러셀 간격 수정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->