### PR TITLE
fix : 콘텐츠 생성 파이프라인 2단계 콘텐츠 검수에서 카테고리 선택 제거

### DIFF
--- a/src/views/admin-pipeline/ui/AdminPipelinePage.tsx
+++ b/src/views/admin-pipeline/ui/AdminPipelinePage.tsx
@@ -100,7 +100,6 @@ export function AdminPipelinePage() {
     koBody: translatedContent?.koBody ?? generatedContent?.body ?? '',
     translatedTitle: translatedContent?.esTitle ?? '',
     translatedBody: translatedContent?.esBody ?? '',
-    category: generatedContent?.category ?? '문화',
   };
 
   function openDraftContentInPipeline(contentId: string | null, contentStep: ContentStep | null) {
@@ -372,7 +371,6 @@ export function AdminPipelinePage() {
   }
 
   function handlePublish() {
-    if (!generatedContent?.category) return;
     if (!translatedContent?.esTitle?.trim() || !getTextFromRichTextHtml(translatedContent.esBody)) {
       return;
     }

--- a/src/views/admin-pipeline/ui/ContentReviewStep.tsx
+++ b/src/views/admin-pipeline/ui/ContentReviewStep.tsx
@@ -6,7 +6,6 @@ import {
   type GeneratedContent,
   type TranslationTargetLanguageSelection,
 } from '../model/mockArticles';
-import { CATEGORIES_KO } from '@/entities/content';
 import { RichTextEditor } from '@/shared/ui/rich-text-editor/RichTextEditor';
 
 interface ContentReviewStepProps {
@@ -33,7 +32,7 @@ export function ContentReviewStep({
   onPrev,
 }: ContentReviewStepProps) {
   const originalText = createMockArticleOriginalText(article);
-  const canGoNext = Boolean(content.category && targetLanguage);
+  const canGoNext = Boolean(targetLanguage);
 
   return (
     <section className="animate-fade-in">
@@ -75,23 +74,7 @@ export function ContentReviewStep({
               </p>
             </div>
 
-            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 xl:w-[320px] xl:flex-shrink-0">
-              <label>
-                <span className="mb-1 block text-[11px] font-bold text-gray-500">카테고리</span>
-                <select
-                  value={content.category}
-                  onChange={(event) => onChange({ ...content, category: event.target.value })}
-                  className="w-full rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm font-bold outline-none transition-colors cursor-pointer focus:border-black"
-                >
-                  <option value="">선택 없음</option>
-                  {CATEGORIES_KO.filter((category) => category !== '전체').map((category) => (
-                    <option key={category} value={category}>
-                      {category}
-                    </option>
-                  ))}
-                </select>
-              </label>
-
+            <div className="xl:w-40 xl:flex-shrink-0">
               <label>
                 <span className="mb-1 block text-[11px] font-bold text-gray-500">번역 언어</span>
                 <select
@@ -162,7 +145,7 @@ export function ContentReviewStep({
                   className="h-11 w-11 flex-shrink-0 object-contain"
                 />
                 <p className="text-xs font-bold leading-relaxed text-gray-700">
-                  카테고리와 번역할 언어를 모두 선택해주세요.
+                  번역할 언어를 선택해주세요.
                 </p>
               </div>
             </div>

--- a/src/views/admin-pipeline/ui/PreviewPublishStep.tsx
+++ b/src/views/admin-pipeline/ui/PreviewPublishStep.tsx
@@ -6,7 +6,6 @@ interface PreviewData {
   koBody: string;
   translatedTitle: string;
   translatedBody: string;
-  category: string;
 }
 
 interface PreviewPublishStepProps {
@@ -43,8 +42,6 @@ export function PreviewPublishStep({
       sessionStorage.setItem('coreahoy-preview-language', lang);
     }
   };
-  const hasCategory = previewData.category.trim().length > 0;
-  const categoryLabel = hasCategory ? previewData.category : '카테고리 미지정';
   const visibleTitle = previewLanguage === 'ko' ? previewData.koTitle : previewData.translatedTitle;
   const visibleBody = previewLanguage === 'ko' ? previewData.koBody : previewData.translatedBody;
   const sanitizedVisibleBody = useMemo(() => sanitizeRichTextHtml(visibleBody), [visibleBody]);
@@ -91,10 +88,7 @@ export function PreviewPublishStep({
       <div className="grid grid-cols-1 gap-5 lg:grid-cols-[360px_1fr]">
         <div className="rounded-[2rem] border-8 border-gray-900 bg-white p-4 shadow-sm">
           <article className="min-h-[520px] rounded-2xl bg-white">
-            <span className="inline-flex rounded-full bg-black px-3 py-1 text-[11px] font-black text-white">
-              {categoryLabel}
-            </span>
-            <h3 className="mt-4 text-2xl font-black leading-tight text-black">{visibleTitle}</h3>
+            <h3 className="text-2xl font-black leading-tight text-black">{visibleTitle}</h3>
             <div
               className="rich-text-renderer mt-5 text-sm leading-7 text-gray-700"
               dangerouslySetInnerHTML={{ __html: sanitizedVisibleBody }}
@@ -103,11 +97,6 @@ export function PreviewPublishStep({
         </div>
 
         <article className="rounded-2xl border border-gray-100 bg-white p-6 shadow-sm">
-          <div className="mb-4 flex flex-wrap items-center gap-2">
-            <span className="rounded-full bg-black px-3 py-1 text-xs font-black text-white">
-              {categoryLabel}
-            </span>
-          </div>
           <h3 className="text-3xl font-black leading-tight text-black">{visibleTitle}</h3>
           <div
             className="rich-text-renderer mt-6 text-sm leading-8 text-gray-700"
@@ -134,10 +123,10 @@ export function PreviewPublishStep({
         <button
           type="button"
           onClick={onPublish}
-          disabled={isPublished || !hasCategory}
+          disabled={isPublished}
           className="rounded-xl bg-black px-5 py-3 text-sm font-black text-white transition-opacity cursor-pointer hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-30"
         >
-          {isPublished ? '발행 완료' : hasCategory ? '발행하기' : '카테고리 선택 필요'}
+          {isPublished ? '발행 완료' : '발행하기'}
         </button>
       </div>
     </section>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #29 

### 📝 작업 내용

> 콘텐츠 생성 파이프라인 2단계 콘텐츠 검수에서 카테고리 선택 제거. 카테고리를 관리자가 직접 지정할 필요 없음.

### 스크린샷 (선택)

<img width="827" height="715" alt="image" src="https://github.com/user-attachments/assets/12e59076-aeb3-4137-bf66-313a26e4c10a" />


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 📚 참고할만한 자료(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 콘텐츠 발행 시 카테고리 선택 요구사항이 제거되었습니다. 이제 번역된 제목과 본문만으로 발행할 수 있습니다.
  * 콘텐츠 검토 단계에서 다음 단계 진행 조건을 단순화했습니다. 대상 언어 선택만 필요합니다.
  * 발행 미리보기 화면에서 카테고리 관련 UI 요소가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->