### PR TITLE
fix: 홈 화면 로딩 UI 및 마이페이지 좋아요 목록 렌더링 수정

### DIFF
--- a/src/entities/user/model/useLikedContents.ts
+++ b/src/entities/user/model/useLikedContents.ts
@@ -4,8 +4,9 @@ import { useUsersStore } from '@/entities/user';
 
 export interface LikedArticle {
   id: string;
-  title: string;
-  titleEs?: string;
+  titleKo: string;
+  titleEs: string;
+  thumbnailUrl?: string;
   category: { id: number; name: string; slug: string } | string;
   publishedAt: string;
 }

--- a/src/views/home/model/useHomeArticles.ts
+++ b/src/views/home/model/useHomeArticles.ts
@@ -78,5 +78,5 @@ export function useHomeArticles({ searchQuery, sortOrder, isKo }: UseHomeArticle
     [latestArticles],
   );
 
-  return { sorted, latestArticles, latestArticleIds, hotArticles };
+  return { sorted, latestArticles, latestArticleIds, hotArticles, hasFetched };
 }

--- a/src/views/home/ui/HomePage.tsx
+++ b/src/views/home/ui/HomePage.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/entities/content';
 import { HotNewsCarousel } from '@/widgets/hot-news';
 import { useHomeArticles } from '../model/useHomeArticles';
+import { Loading } from '@/shared/ui/loading/Loading';
 
 const SORT_OPTIONS = [
   { id: 'latest' as const, ko: '최신순', es: 'Reciente' },
@@ -34,7 +35,7 @@ function HomePageInner() {
   const activeCategory = searchParams.get('category');
   const isMainLanding = !activeCategory && !searchQuery;
 
-  const { sorted, latestArticles, hotArticles } = useHomeArticles({
+  const { sorted, latestArticles, hotArticles, hasFetched } = useHomeArticles({
     searchQuery,
     sortOrder,
     isKo,
@@ -161,7 +162,8 @@ function HomePageInner() {
         )}
 
         {/* ── Empty state ── */}
-        {sorted.length === 0 && (
+        {!hasFetched && <Loading />}
+        {hasFetched && sorted.length === 0 && (
           <div className="py-24 text-center">
             <span className="text-5xl mb-4 block">🔍</span>
             <p className="text-lg font-bold text-gray-300 mb-6">{t('noResults')}</p>

--- a/src/views/mypage/ui/LikedContentList.tsx
+++ b/src/views/mypage/ui/LikedContentList.tsx
@@ -4,6 +4,22 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { useTranslations, useLocale } from 'next-intl';
 import { useLikedContents } from '@/entities/user';
+import { useState } from 'react';
+
+function LikedItemImage({ src, alt }: { src?: string; alt: string }) {
+  const [imgSrc, setImgSrc] = useState(src || '/images/characters/mascot-cheer.png');
+
+  return (
+    <Image
+      src={imgSrc}
+      alt={alt}
+      fill
+      sizes="96px"
+      className="object-cover"
+      onError={() => setImgSrc('/images/characters/mascot-cheer.png')}
+    />
+  );
+}
 
 export function LikedContentList() {
   const t = useTranslations('mypage');
@@ -48,13 +64,10 @@ export function LikedContentList() {
               href={`/article/${c.id}`}
               className="group flex gap-3 border border-gray-100 bg-white rounded-xl overflow-hidden hover:border-black transition-all duration-200"
             >
-              <div className="relative w-24 h-20 flex-shrink-0">
-                <Image
-                  src={`https://picsum.photos/seed/${c.id}/240/160`}
-                  alt={isKo ? c.title : (c.titleEs ?? c.title)}
-                  fill
-                  sizes="96px"
-                  className="object-cover"
+              <div className="relative w-28 sm:w-32 flex-shrink-0 bg-gray-50">
+                <LikedItemImage
+                  src={c.thumbnailUrl}
+                  alt={isKo ? c.titleKo : (c.titleEs ?? c.titleKo)}
                 />
               </div>
               <div className="flex flex-col justify-center gap-1 py-3 pr-3 min-w-0">
@@ -62,7 +75,7 @@ export function LikedContentList() {
                   {typeof c.category === 'object' ? c.category.name : c.category}
                 </span>
                 <p className="font-bold text-sm leading-snug group-hover:underline line-clamp-2">
-                  {isKo ? c.title : (c.titleEs ?? c.title)}
+                  {isKo ? c.titleKo : (c.titleEs ?? c.titleKo)}
                 </p>
                 <span className="text-xs text-gray-300">{c.publishedAt}</span>
               </div>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#57 

### 📝 작업 내용

메인화면 로딩창 추가 및 마이페이지에서 기사 제목이 뜨지 않는 버그를 수정했슴다

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

## 📚 참고할만한 자료(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 콘텐츠 로딩 상태를 명확하게 표시하는 로딩 인디케이터 추가
  * 썸네일 이미지 오류 발생 시 기본 이미지로 자동 대체 기능 추가

* **Improvements**
  * 다국어(한국어, 스페인어) 제목 지원 확대
  * 좋아요 목록의 이미지 처리 및 표시 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Corea-Hoy/Corea-Hoy-FE/pull/58)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->